### PR TITLE
fix `.constructor` when disowning

### DIFF
--- a/src/compiler/generators.ts
+++ b/src/compiler/generators.ts
@@ -673,7 +673,10 @@ export function generateStructFieldMethods(
 
   // _disownFoo(): capnp.Orphan<Foo> { return $.utils.disown(this.foo); }
   if (disown) {
-    const getter = f.createPropertyAccessExpression(THIS, name);
+    const getter = f.createPropertyAccessExpression(
+      THIS,
+      name === "constructor" ? `$${name}` : name,
+    );
     const expressions = [
       f.createCallExpression(
         f.createPropertyAccessExpression(UTILS, "disown"),


### PR DESCRIPTION
Apply the fix in https://github.com/unjs/capnp-es/pull/10 to disown functions.

Without this change, we were seeing generated TS files like:

```ts
  _disownConstructor(): $.Orphan<Constructor> {
    return $.utils.disown(this.constructor);
  }
```
which failed with:

```
Argument of type 'Function' is not assignable to parameter of type 'Pointer<_Pointer>'.
  Type 'Function' is missing the following properties from type 'Pointer<_Pointer>': _capnp, byteOffset, segment, [Symbol.toStringTag]
Error: CAPNP-ES009 Failed to transpile emitted schema source code; see above for error messages.
```
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->
