### PR TITLE
feat: Change the default output format to `ts`

### DIFF
--- a/src/compiler/main.ts
+++ b/src/compiler/main.ts
@@ -37,7 +37,7 @@ Options:
 const sources: string[] = [];
 const options: string[] = [];
 
-let outFormats: string[] = ["js"];
+let outFormats: string[] = ["ts"];
 let outDir: string | undefined;
 
 for (const arg of process.argv.slice(2)) {


### PR DESCRIPTION
When running `capnp-es` as a `capnpc` compiler plugin, it's not possible to customize the output flags. As such, `capnp-es` only generates `.js` output—this PR changes the default output format to `ts`.

I suppose technically it's a breaking change?
