### PR TITLE
fix(enum): fix enum value

### DIFF
--- a/src/capnp/rpc-twoparty.ts
+++ b/src/capnp/rpc-twoparty.ts
@@ -2,7 +2,25 @@
 import * as $ from "capnp-es";
 export const _capnpFileId = BigInt("0xa184c7885cdaf2a1");
 export const Side = {
+  /**
+* The object lives on the "server" or "supervisor" end of the connection. Only the
+* server/supervisor knows how to interpret the ref; to the client, it is opaque.
+*
+* Note that containers intending to implement strong confinement should rewrite SturdyRefs
+* received from the external network before passing them on to the confined app. The confined
+* app thus does not ever receive the raw bits of the SturdyRef (which it could perhaps
+* maliciously leak), but instead receives only a thing that it can pass back to the container
+* later to restore the ref. See:
+* http://www.erights.org/elib/capability/dist-confine.html
+*
+*/
   SERVER: 0,
+  /**
+* The object lives on the "client" or "confined app" end of the connection. Only the client
+* knows how to interpret the ref; to the server/supervisor, it is opaque. Most clients do not
+* actually know how to persist capabilities at all, so use of this is unusual.
+*
+*/
   CLIENT: 1
 } as const;
 export type Side = (typeof Side)[keyof typeof Side];

--- a/src/capnp/schema.ts
+++ b/src/capnp/schema.ts
@@ -480,10 +480,38 @@ export class Node_Annotation extends $.Struct {
 }
 export const Node_Which = {
   FILE: 0,
+  /**
+* Name to present to humans to identify this Node.  You should not attempt to parse this.  Its
+* format could change.  It is not guaranteed to be unique.
+*
+* (On Zooko's triangle, this is the node's nickname.)
+*
+*/
   STRUCT: 1,
+  /**
+* If you want a shorter version of `displayName` (just naming this node, without its surrounding
+* scope), chop off this many characters from the beginning of `displayName`.
+*
+*/
   ENUM: 2,
+  /**
+* ID of the lexical parent node.  Typically, the scope node will have a NestedNode pointing back
+* at this node, but robust code should avoid relying on this (and, in fact, group nodes are not
+* listed in the outer struct's nestedNodes, since they are listed in the fields).  `scopeId` is
+* zero if the node has no parent, which is normally only the case with files, but should be
+* allowed for any kind of node (in order to make runtime type generation easier).
+*
+*/
   INTERFACE: 3,
+  /**
+* List of nodes nested within this node, along with the names under which they were declared.
+*
+*/
   CONST: 4,
+  /**
+* Annotations applied to this node.
+*
+*/
   ANNOTATION: 5
 } as const;
 export type Node_Which = (typeof Node_Which)[keyof typeof Node_Which];
@@ -804,6 +832,13 @@ export class Field_Group extends $.Struct {
 }
 export const Field_Ordinal_Which = {
   IMPLICIT: 0,
+  /**
+* The original ordinal number given to the field.  You probably should NOT use this; if you need
+* a numeric identifier for a field, use its position within the field array for its scope.
+* The ordinal is given here mainly just so that the original schema text can be reproduced given
+* the compiled version -- i.e. so that `capnp compile -ocapnp` can do its job.
+*
+*/
   EXPLICIT: 1
 } as const;
 export type Field_Ordinal_Which = (typeof Field_Ordinal_Which)[keyof typeof Field_Ordinal_Which];
@@ -846,6 +881,15 @@ export class Field_Ordinal extends $.Struct {
 }
 export const Field_Which = {
   SLOT: 0,
+  /**
+* Indicates where this member appeared in the code, relative to other members.
+* Code ordering may have semantic relevance -- programmers tend to place related fields
+* together.  So, using code ordering makes sense in human-readable formats where ordering is
+* otherwise irrelevant, like JSON.  The values of codeOrder are tightly-packed, so the maximum
+* value is count(members) - 1.  Fields that are members of a union are only ordered relative to
+* the other members of that union, so the maximum value there is count(union.members).
+*
+*/
   GROUP: 1
 } as const;
 export type Field_Which = (typeof Field_Which)[keyof typeof Field_Which];
@@ -1306,9 +1350,25 @@ export class Type_Interface extends $.Struct {
   toString(): string { return "Type_Interface_" + super.toString(); }
 }
 export const Type_AnyPointer_Unconstrained_Which = {
+  /**
+* truly AnyPointer
+*
+*/
   ANY_KIND: 0,
+  /**
+* AnyStruct
+*
+*/
   STRUCT: 1,
+  /**
+* AnyList
+*
+*/
   LIST: 2,
+  /**
+* Capability
+*
+*/
   CAPABILITY: 3
 } as const;
 export type Type_AnyPointer_Unconstrained_Which = (typeof Type_AnyPointer_Unconstrained_Which)[keyof typeof Type_AnyPointer_Unconstrained_Which];
@@ -1412,8 +1472,25 @@ export class Type_AnyPointer_ImplicitMethodParameter extends $.Struct {
   toString(): string { return "Type_AnyPointer_ImplicitMethodParameter_" + super.toString(); }
 }
 export const Type_AnyPointer_Which = {
+  /**
+* A regular AnyPointer.
+*
+* The name "unconstrained" means as opposed to constraining it to match a type parameter.
+* In retrospect this name is probably a poor choice given that it may still be constrained
+* to be a struct, list, or capability.
+*
+*/
   UNCONSTRAINED: 0,
+  /**
+* This is actually a reference to a type parameter defined within this scope.
+*
+*/
   PARAMETER: 1,
+  /**
+* This is actually a reference to an implicit (generic) parameter of a method. The only
+* legal context for this type to appear is inside Method.paramBrand or Method.resultBrand.
+*
+*/
   IMPLICIT_METHOD_PARAMETER: 2
 } as const;
 export type Type_AnyPointer_Which = (typeof Type_AnyPointer_Which)[keyof typeof Type_AnyPointer_Which];
@@ -1701,7 +1778,15 @@ export class Type extends $.Struct {
   }
 }
 export const Brand_Scope_Which = {
+  /**
+* ID of the scope to which these params apply.
+*
+*/
   BIND: 0,
+  /**
+* List of parameter bindings.
+*
+*/
   INHERIT: 1
 } as const;
 export type Brand_Scope_Which = (typeof Brand_Scope_Which)[keyof typeof Brand_Scope_Which];
@@ -1871,6 +1956,11 @@ export const Value_Which = {
   LIST: 14,
   ENUM: 15,
   STRUCT: 16,
+  /**
+* The only interface value that can be represented statically is "null", whose methods always
+* throw exceptions.
+*
+*/
   INTERFACE: 17,
   ANY_POINTER: 18
 } as const;
@@ -2218,6 +2308,10 @@ export class Annotation extends $.Struct {
   toString(): string { return "Annotation_" + super.toString(); }
 }
 export const ElementSize = {
+  /**
+* aka "void", but that's a keyword.
+*
+*/
   EMPTY: 0,
   BIT: 1,
   BYTE: 2,

--- a/src/compiler/generators/enum.ts
+++ b/src/compiler/generators/enum.ts
@@ -1,24 +1,38 @@
 import * as schema from "../../capnp/schema";
-import { compareCodeOrder } from "../node-util";
+import { compareCodeOrder, lookupNodeSourceInfo } from "../node-util";
 import * as util from "../util";
 import type { CodeGeneratorFileContext } from ".";
+import { extractJSDocs } from "./helpers";
 
 /**
  * Generates TypeScript enum code from Cap'n Proto enum definitions.
  *
  * @param ctx - The file context containing schema information and output statements
  * @param className - The name to use for the generated enum type and const object
+ * @param parentNode - The parent of the fields used to retrieve the source info (comments)
  * @param fields - Array of enum fields containing names and optional discriminant values
  */
 export function generateEnumNode(
   ctx: CodeGeneratorFileContext,
   className: string,
+  parentNode: schema.Node,
   fields: schema.Enumerant[] | schema.Field[],
 ): void {
-  const propInits = fields.sort(compareCodeOrder).map((e, index) => {
-    const key = util.c2s(e.name);
-    const val = (e as schema.Field).discriminantValue || index;
-    return `${key}: ${val}`;
+  const fieldIndexInCodeOrder = fields
+    .map(({ codeOrder }, fieldIndex) => ({ fieldIndex, codeOrder }))
+    .sort(compareCodeOrder)
+    .map(({ fieldIndex }) => fieldIndex);
+
+  const sourceInfo = lookupNodeSourceInfo(ctx, parentNode);
+
+  const propInits = fieldIndexInCodeOrder.map((index) => {
+    const field = fields[index];
+    const docComment = extractJSDocs(sourceInfo?.members.at(index));
+    const key = util.c2s(field.name);
+    const val = (field as schema.Field).discriminantValue || index;
+    return `
+      ${docComment}
+      ${key}: ${val}`;
   });
 
   ctx.codeParts.push(`

--- a/src/compiler/generators/index.ts
+++ b/src/compiler/generators/index.ts
@@ -67,6 +67,7 @@ export function generateNode(
       generateEnumNode(
         ctx,
         getFullClassName(node),
+        node,
         node.enum.enumerants.toArray(),
       );
       break;

--- a/test/fixtures/serialization-demo.ts
+++ b/test/fixtures/serialization-demo.ts
@@ -32,6 +32,10 @@ export const Person_Employment_Which = {
   UNEMPLOYED: 0,
   EMPLOYER: 1,
   SCHOOL: 2,
+  /**
+* We assume that a person is only one of these.
+*
+*/
   SELF_EMPLOYED: 3
 } as const;
 export type Person_Employment_Which = (typeof Person_Employment_Which)[keyof typeof Person_Employment_Which];

--- a/test/fixtures/test.capnp
+++ b/test/fixtures/test.capnp
@@ -28,14 +28,14 @@ using Cxx = import "/capnp/c++.capnp";
 $Cxx.namespace("capnproto_test::capnp::test");
 
 enum TestEnum {
-  foo @0;
-  bar @1;
+  foo @0; # foo
+  garply @7; # garply
+  bar @1; #bar
   baz @2;
   qux @3;
   quux @4;
   corge @5;
   grault @6;
-  garply @7;
 }
 
 struct TestAllTypes {
@@ -913,10 +913,10 @@ struct TestSturdyRefHostId {
 struct TestSturdyRefObjectId {
   tag @0 :Tag;
   enum Tag {
-    testInterface @0;
+    testInterface @0; # testInterface
+    testTailCallee @3; # testTailCallee
     testExtends @1;
     testPipeline @2;
-    testTailCallee @3;
     testTailCaller @4;
     testMoreStuff @5;
   }

--- a/test/fixtures/test.ts
+++ b/test/fixtures/test.ts
@@ -2,14 +2,26 @@
 import * as $ from "capnp-es";
 export const _capnpFileId = BigInt("0xd508eebdc2dc42b8");
 export const TestEnum = {
+  /**
+* foo
+*
+*/
   FOO: 0,
+  /**
+* garply
+*
+*/
+  GARPLY: 7,
+  /**
+* bar
+*
+*/
   BAR: 1,
   BAZ: 2,
   QUX: 3,
   QUUX: 4,
   CORGE: 5,
-  GRAULT: 6,
-  GARPLY: 7
+  GRAULT: 6
 } as const;
 export type TestEnum = (typeof TestEnum)[keyof typeof TestEnum];
 export class TestAllTypes extends $.Struct {
@@ -1514,7 +1526,7 @@ export const TestUnion_Union2_Which = {
   U2F0S32: 3,
   U2F0S16: 2,
   U2F0S8: 1,
-  U2F0S1: 4
+  U2F0S1: 0
 } as const;
 export type TestUnion_Union2_Which = (typeof TestUnion_Union2_Which)[keyof typeof TestUnion_Union2_Which];
 export class TestUnion_Union2 extends $.Struct {
@@ -1593,7 +1605,7 @@ export const TestUnion_Union3_Which = {
   U3F0S32: 3,
   U3F0S16: 2,
   U3F0S8: 1,
-  U3F0S1: 4
+  U3F0S1: 0
 } as const;
 export type TestUnion_Union3_Which = (typeof TestUnion_Union3_Which)[keyof typeof TestUnion_Union3_Which];
 export class TestUnion_Union3 extends $.Struct {
@@ -7586,10 +7598,18 @@ export class TestSturdyRefHostId extends $.Struct {
   toString(): string { return "TestSturdyRefHostId_" + super.toString(); }
 }
 export const TestSturdyRefObjectId_Tag = {
+  /**
+* testInterface
+*
+*/
   TEST_INTERFACE: 0,
+  /**
+* testTailCallee
+*
+*/
+  TEST_TAIL_CALLEE: 3,
   TEST_EXTENDS: 1,
   TEST_PIPELINE: 2,
-  TEST_TAIL_CALLEE: 3,
   TEST_TAIL_CALLER: 4,
   TEST_MORE_STUFF: 5
 } as const;


### PR DESCRIPTION
enum values used to be the code order while they should be field order
also add value comments from the capnp in the generated file

Before this PR the generated code would look like:

```ts
export const TestEnum = {
  FOO: 0,
  GARPLY: 1,
  BAR: 2,
  BAZ: 3,
  QUX: 4,
  QUUX: 5,
  CORGE: 6,
  GRAULT: 7
} as const;
```

and now is fixed as

```ts
export const TestEnum = {
  /**
* foo
*
*/
  FOO: 0,
  /**
* garply
*
*/
  GARPLY: 7,
  /**
* bar
*
*/
  BAR: 1,
  BAZ: 2,
  QUX: 3,
  QUUX: 4,
  CORGE: 5,
  GRAULT: 6
} as const;
```

Notice that the value are fixed and match the `@<N>` in the .capnp file and the added comments.

Also before this PR:

```
export const TestUnion_Union3_Which = {
  U3F0S64: 4,
  U3F0S32: 3,
  U3F0S16: 2,
  U3F0S8: 1,
  U3F0S1: 4
} as const;
```

and after:

```
export const TestUnion_Union3_Which = {
  U3F0S64: 4,
  U3F0S32: 3,
  U3F0S16: 2,
  U3F0S8: 1,
  U3F0S1: 0
} as const;
```

Verified using the C++ implementation generating (note that the C++ implementation does not bother respecting the code order).

```c++
  enum Which: uint16_t {
    U2F0S1,
    U2F0S8,
    U2F0S16,
    U2F0S32,
    U2F0S64,
  };
```

/cc @emily-shen @penalosa

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 5 in a stack** made with GitButler:
- <kbd>&nbsp;5&nbsp;</kbd> #35 
- <kbd>&nbsp;4&nbsp;</kbd> #34 
- <kbd>&nbsp;3&nbsp;</kbd> #33 
- <kbd>&nbsp;2&nbsp;</kbd> #32 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #31 
<!-- GitButler Footer Boundary Bottom -->

