### PR TITLE
Fix/external type references

### DIFF
--- a/src/compiler/generators/imports.ts
+++ b/src/compiler/generators/imports.ts
@@ -1,6 +1,6 @@
 import type { CodeGeneratorFileContext } from ".";
 import { TS_FILE_ID } from "../constants";
-import { getFullClassName, hasNode, lookupNode } from "../node-util";
+import { getFullClassName, hasNode, lookupNode, tryLookupNode } from "../node-util";
 import * as util from "../util";
 import type * as schema from "../../capnp/schema";
 
@@ -60,7 +60,11 @@ export function generateNestedImports(ctx: CodeGeneratorFileContext): void {
       }
     }
 
-    const importNode = lookupNode(ctx, imp);
+    const importNode = tryLookupNode(ctx, imp);
+    if (!importNode) {
+      // Skip imports for nodes that aren't available in the current context
+      continue;
+    }
 
     const imports = getImportNodes(ctx, importNode)
       .flatMap((node) => {

--- a/src/compiler/generators/imports.ts
+++ b/src/compiler/generators/imports.ts
@@ -1,6 +1,11 @@
 import type { CodeGeneratorFileContext } from ".";
 import { TS_FILE_ID } from "../constants";
-import { getFullClassName, hasNode, lookupNode, tryLookupNode } from "../node-util";
+import {
+  getFullClassName,
+  hasNode,
+  lookupNode,
+  tryLookupNode,
+} from "../node-util";
 import * as util from "../util";
 import type * as schema from "../../capnp/schema";
 

--- a/src/compiler/node-util.ts
+++ b/src/compiler/node-util.ts
@@ -31,13 +31,12 @@ export function getConcreteListType(
   } else if (elementTypeWhich === schema.Type.STRUCT) {
     const structNode = tryLookupNode(ctx, elementType.struct.typeId);
 
-    if (structNode) {
-      if (
-        structNode.struct.preferredListEncoding !==
+    if (
+      structNode &&
+      structNode.struct.preferredListEncoding !==
         schema.ElementSize.INLINE_COMPOSITE
-      ) {
-        throw new Error(E.GEN_FIELD_NON_INLINE_STRUCT_LIST);
-      }
+    ) {
+      throw new Error(E.GEN_FIELD_NON_INLINE_STRUCT_LIST);
     }
 
     return `$.CompositeList(${getJsType(ctx, elementType, false)})`;

--- a/src/compiler/node-util.ts
+++ b/src/compiler/node-util.ts
@@ -29,13 +29,15 @@ export function getConcreteListType(
   if (elementTypeWhich === schema.Type.LIST) {
     return `$.PointerList(${getConcreteListType(ctx, elementType)})`;
   } else if (elementTypeWhich === schema.Type.STRUCT) {
-    const structNode = lookupNode(ctx, elementType.struct.typeId);
+    const structNode = tryLookupNode(ctx, elementType.struct.typeId);
 
-    if (
-      structNode.struct.preferredListEncoding !==
-      schema.ElementSize.INLINE_COMPOSITE
-    ) {
-      throw new Error(E.GEN_FIELD_NON_INLINE_STRUCT_LIST);
+    if (structNode) {
+      if (
+        structNode.struct.preferredListEncoding !==
+        schema.ElementSize.INLINE_COMPOSITE
+      ) {
+        throw new Error(E.GEN_FIELD_NON_INLINE_STRUCT_LIST);
+      }
     }
 
     return `$.CompositeList(${getJsType(ctx, elementType, false)})`;
@@ -85,7 +87,12 @@ export function getJsType(
     }
 
     case schema.Type.ENUM: {
-      return getFullClassName(lookupNode(ctx, type.enum.typeId));
+      const node = tryLookupNode(ctx, type.enum.typeId);
+      if (!node) {
+        // External enum type - generate a placeholder type name
+        return `Enum_${type.enum.typeId.toString(16)}`;
+      }
+      return getFullClassName(node);
     }
 
     case schema.Type.FLOAT32:
@@ -105,7 +112,12 @@ export function getJsType(
     }
 
     case schema.Type.INTERFACE: {
-      return getFullClassName(lookupNode(ctx, type.interface.typeId));
+      const node = tryLookupNode(ctx, type.interface.typeId);
+      if (!node) {
+        // External interface type - generate a placeholder type name
+        return `Interface_${type.interface.typeId.toString(16)}`;
+      }
+      return getFullClassName(node);
     }
 
     case schema.Type.LIST: {
@@ -113,8 +125,13 @@ export function getJsType(
     }
 
     case schema.Type.STRUCT: {
-      const c = getFullClassName(lookupNode(ctx, type.struct.typeId));
-
+      const node = tryLookupNode(ctx, type.struct.typeId);
+      if (!node) {
+        // External struct type - generate a placeholder type name
+        const c = `Struct_${type.struct.typeId.toString(16)}`;
+        return constructor ? `$.StructCtor<${c}>` : c;
+      }
+      const c = getFullClassName(node);
       return constructor ? `$.StructCtor<${c}>` : c;
     }
 
@@ -194,6 +211,21 @@ export function lookupNode(
   }
 
   return node;
+}
+
+/**
+ * Attempts to look up a Node in the schema by its ID without throwing.
+ *
+ * @param ctx - The file context containing all nodes from the schema
+ * @param lookup - Either a Node ID as a bigint, or an object containing an ID field
+ * @returns The found Node from the schema, or undefined if not found
+ */
+export function tryLookupNode(
+  ctx: CodeGeneratorFileContext,
+  lookup: { readonly id: bigint } | bigint,
+): schema.Node | undefined {
+  const id = typeof lookup === "bigint" ? lookup : lookup.id;
+  return ctx.nodes.find((n) => n.id === id);
 }
 
 /**


### PR DESCRIPTION
The TypeScript code generator throws an error when it encounters references to external types that aren't available in the current compilation context. This happens when a Cap'n Proto schema imports types from other schemas that aren't being compiled in the same invocation.

When the compiler encounters an external type reference (struct, enum, or interface) that isn't in the current node context, it throws an error in lookupNode() with message: "missing node".

**Expected Behavior**

The compiler should gracefully handle external type references by generating placeholder type names, allowing the compilation to complete successfully.

**Changes**

- Add a tryLookupNode function that returns undefined instead of throwing when a node isn't found
- Generate placeholder type names (e.g., Struct_${typeId}, Enum_${typeId}) for external types
- This allows TypeScript generation to complete while maintaining type safety

**Impact**

This fix prevents compilation failures in projects with modular schema organization where not all referenced types are available during every compilation run.


Resolves #45 
