### PR TITLE
fix: do not pass the output directory to capnpc

### DIFF
--- a/src/compiler/cli.ts
+++ b/src/compiler/cli.ts
@@ -27,7 +27,7 @@ export async function cliMain(outFormat: "js" | "ts" | "dts") {
       outFormats = parsedOptions.outFormats;
       outDir = parsedOptions.outDir;
       const { sources, options } = parsedOptions;
-      dataBuf = await execCapnpc(sources, options, outDir);
+      dataBuf = await execCapnpc(sources, options);
     }
     const { files } = await compileAll(dataBuf, {
       ts: outFormats.includes("ts"),
@@ -99,14 +99,9 @@ function parseOptions() {
 async function execCapnpc(
   sources: string[],
   options: string[],
-  outDir: string | undefined,
 ): Promise<Buffer> {
-  if (outDir) {
-    options.push(`-o-:${outDir}`);
-  } else {
-    options.push("-o-");
-  }
-  const cmd = `capnpc ${options.join(" ")} ${sources.join(" ")}`;
+  // Uses -o- to output to stdout
+  const cmd = `capnpc -o- ${options.join(" ")} ${sources.join(" ")}`;
   console.log(`[capnp-es] ${cmd}`);
   return new Promise<Buffer>((resolve) => {
     exec(cmd, { encoding: "buffer" }, (error, stdout, stderr) => {


### PR DESCRIPTION
Before this PR, the output directory is passed to `capnpc` which causes an error if the directory does not exists.
In addition `capnpc` does not use the output directory as it outputs to stdout.

So this PR simplify the code to not pass the output directory to `capnpc`.

More details:

Executing `capnp-es file.capnp --output=ts:outfolder` was executing `capnpc -o-:outfolder  file.capnp` which would error when `outfolder` does not exist (even though `capnpc` does not use this directory but the stdout instead).

After this PR we execute `capnpc -o- file.capnp` and the `outfolder` is created by `capnp-es` if it doesn't exist yet.
